### PR TITLE
RNAseq + single-end sequencing

### DIFF
--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -175,6 +175,7 @@ createGenericGraph(callOptions & CO,
   while (number_of_exons >= 1)
   {
     // Intron
+    if (!CO.rnaseq)
     {
       tmp_string = base_path.str();
       std::string intron = "i";
@@ -301,6 +302,7 @@ create_exon_2_and_3_graph(callOptions & CO,
   while (number_of_exons >= 1)
   {
     // Intron
+    if (!CO.rnaseq)
     {
       tmp_string = base_path.str();
       std::string intron = "i";

--- a/src/graph.hpp
+++ b/src/graph.hpp
@@ -185,6 +185,8 @@ struct callOptions
   bool vcf;
   bool bias_check;
   bool thousand_genomes;
+  bool rnaseq;
+  bool singleend;
   int read_gap;
 
   void print_options(){
@@ -210,12 +212,14 @@ struct callOptions
     std::cout << "CO.vcf " << vcf << std::endl;
     std::cout << "CO.bias_check " << bias_check << std::endl;
     std::cout << "CO.thousand_genomes " << thousand_genomes << std::endl;
+    std::cout << "CO.rnaseq " << rnaseq << std::endl;
+    std::cout << "CO.singleend " << singleend << std::endl;
     std::cout << "CO.read_gap " << read_gap << std::endl;
   };
 
 callOptions():
   beta_list("0.6"), bpQclip(30), bpQskip(25), number_of_exons(4), kmer(15), min_kmers(1), gene("DQA1"), minSeqLen_list("60"), outputFolder(),
-  vcfOutputFolder(), verbose(false), exon_2_and_3(false), vcf(false), bias_check(false), thousand_genomes(false), read_gap(1000) {}
+  vcfOutputFolder(), verbose(false), exon_2_and_3(false), vcf(false), bias_check(false), thousand_genomes(false), rnaseq(false), singleend(false), read_gap(1000) {}
 };
 
 


### PR DESCRIPTION
Added RNA-Seq feature that removes the introns from the partial order graph.
Added single-end option that skips SAM flag 'first read in pair' check, and removes the paired end constraints from Gyper.

Do you think it sensible?
